### PR TITLE
feat(http): adds timeout

### DIFF
--- a/nomad-exporter.go
+++ b/nomad-exporter.go
@@ -8,7 +8,9 @@ import (
 	"net/http"
 	"os"
 	"strings"
+        "strconv"
 	"sync"
+        "time"
 
 	"github.com/hashicorp/nomad/api"
 	"github.com/prometheus/client_golang/prometheus"
@@ -320,6 +322,7 @@ func main() {
 		listenAddress = flag.String("web.listen-address", ":9172", "Address to listen on for web interface and telemetry.")
 		metricsPath   = flag.String("web.telemetry-path", "/metrics", "Path under which to expose metrics.")
 		nomadServer   = flag.String("nomad.server", "http://localhost:4646", "HTTP API address of a Nomad server or agent.")
+		nomadTimeout  = flag.String("nomad.timeout", "30", "HTTP timeout to contact Nomad agent.")
 		tlsCaFile     = flag.String("tls.ca-file", "", "ca-file path to a PEM-encoded CA cert file to use to verify the connection to nomad server")
 		tlsCaPath     = flag.String("tls.ca-path", "", "ca-path is the path to a directory of PEM-encoded CA cert files to verify the connection to nomad server")
 		tlsCert       = flag.String("tls.cert-file", "", "cert-file is the path to the client certificate for Nomad communication")
@@ -344,6 +347,12 @@ func main() {
 		cfg.TLSConfig.Insecure = *tlsInsecure
 		cfg.TLSConfig.TLSServerName = *tlsServerName
 	}
+
+        timeout, err := strconv.Atoi(*nomadTimeout)
+        if err != nil {
+                log.Fatal(err)
+        }
+        cfg.HttpClient.Timeout = time.Duration(timeout) * time.Second
 
 	exporter, err := NewExporter(cfg)
 	if err != nil {

--- a/nomad-exporter.go
+++ b/nomad-exporter.go
@@ -7,10 +7,10 @@ import (
 	"math"
 	"net/http"
 	"os"
+	"strconv"
 	"strings"
-        "strconv"
 	"sync"
-        "time"
+	"time"
 
 	"github.com/hashicorp/nomad/api"
 	"github.com/prometheus/client_golang/prometheus"
@@ -348,11 +348,11 @@ func main() {
 		cfg.TLSConfig.TLSServerName = *tlsServerName
 	}
 
-        timeout, err := strconv.Atoi(*nomadTimeout)
-        if err != nil {
-                log.Fatal(err)
-        }
-        cfg.HttpClient.Timeout = time.Duration(timeout) * time.Second
+	timeout, err := strconv.Atoi(*nomadTimeout)
+	if err != nil {
+		log.Fatal(err)
+	}
+	cfg.HttpClient.Timeout = time.Duration(timeout) * time.Second
 
 	exporter, err := NewExporter(cfg)
 	if err != nil {


### PR DESCRIPTION
```
# timeout: 3s
go run nomad-exporter.go -nomad.server="http://1.2.3.4:4646" -nomad.timeout 3
```